### PR TITLE
Allow negative numbers for amounts, use long args in tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ enum Commands {
     /// Add a new entry to the CSV file
     NewEntry {
         /// Amount to add
-        #[arg(short, long)]
+        #[arg(short, long, allow_negative_numbers = true)]
         amount: Decimal,
         /// Date of the entry (e.g. 2024-12-12, defaults to today)
         #[arg(short, long)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -261,9 +261,9 @@ impl NewEntryArgs {
 
     fn cmd(&self, file: &Path) -> Command {
         let mut cmd = mfinance();
-        cmd.arg("new-entry").arg(format!("-a={}", self.amount));
+        cmd.arg("new-entry").arg("--amount").arg(self.amount);
         if let Some(date) = self.date {
-            cmd.arg(format!("-d={}", date));
+            cmd.arg("--date").arg(date);
         }
         cmd.arg(file.as_os_str());
         cmd
@@ -288,7 +288,7 @@ impl ReportArgs {
         let mut cmd = mfinance();
         cmd.arg("report");
         if let Some(filter) = self.filter {
-            cmd.arg(format!("-f={filter}"));
+            cmd.arg("--filter").arg(filter);
         }
         cmd.arg(file.as_os_str());
         cmd


### PR DESCRIPTION
Previously only `--amount=-<number>` worked